### PR TITLE
Fixes bug where an empty calendar displayed other calendar's events.

### DIFF
--- a/core/components/eventscalendar2/model/eventscalendar2/eventscalendar2.class.php
+++ b/core/components/eventscalendar2/model/eventscalendar2/eventscalendar2.class.php
@@ -313,7 +313,10 @@ class eventsCalendar2 {
 				$query->andCondition(array('isfolder' => 0));
 			}
 		}
-		else {$this->error('no_result');} // У документа нет потомков - это ошибка
+		else {
+			$this->error('no_result'); // У документа нет потомков - это ошибка
+			return array();
+			}
 		
 		// Если источником события задан TV параметр - работаем по нему
 		if (preg_match('/^tv/i', $this->config['dateSource'])) {


### PR DESCRIPTION
Fixes bug for multiple calendars.

Previously if multiple calendars existed, but the calendar being displayed was empty, then events from all other calendars would be shown on the empty calendar.
